### PR TITLE
Strip signatures from the end of SMS messages

### DIFF
--- a/ddotapi.js
+++ b/ddotapi.js
@@ -150,6 +150,12 @@ module.exports = (function () {
       }
 
       var data = JSON.parse(body);
+
+      if (!data.data || !data.data.entry) {
+        def.reject(new Error('No results for stop ' + stopId));
+        return def.promise;
+      }
+
       var now = data.currentTime;
       var arrivals = data.data.entry.arrivalsAndDepartures
       .map(function (entry) {


### PR DESCRIPTION
Test for various forms of signatues at the end of the incoming messages.
Try to strip them off without being so aggressive that we mangle valid
requests that we would have understood.
