### PR TITLE
Add some robustness for multiple-choice options

### DIFF
--- a/sms-flow.js
+++ b/sms-flow.js
@@ -299,7 +299,9 @@ function tryContinueMultiConversation(sms, context) {
   for (i = 0; i < context.choices.length; i += 1) {
     var choice = context.choices[i];
     if (startsWith(sms, choice, {caseSensitive: false}) &&
-        (sms.length === choice.length || sms[choice.length] === ' ')) {
+        (sms.length === choice.length ||
+         sms[choice.length] === ' ' ||
+         sms[choice.length] === ')')) {
       index = i;
       break;
     }


### PR DESCRIPTION
If the user responds with "A)16" or "A) 16", rather than just "A", we
should still know that he chose A.
