### PR TITLE
Reduce the wait time between Google geocode requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 .DS_Store
-.env
-
+*.env
+!sample.env

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,4 @@
+## Tests
+
+Just run `mocha`
+

--- a/geocoder-google.js
+++ b/geocoder-google.js
@@ -9,7 +9,7 @@ var url = require('url');
 var Q = require('q');
 
 var apiUrl = 'http://maps.googleapis.com/maps/api/geocode/json';
-var minPause = 1000;
+var minPause = 200;
 
 module.exports = (function () {
   var self = {};
@@ -20,7 +20,6 @@ module.exports = (function () {
     var urlObj = url.parse(apiUrl);
     // TODO: use viewport biasing with the bounds parameter
     urlObj.query = {
-      sensor: false,
       address: line1 + ', ' + line2
     };
 

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,13 @@
+OBA_API=''
+LOGGER_URL=''
+
+# Geocoders
+DATABASE_URL='postgres://'
+YBOSS_KEY=''
+YBOSS_SECRET=''
+MAX_GEOCACHE_COUNT='10000'
+
+# Setting these variables will trigger automatic "we're offline"-type messages
+# for users.
+# NOBUSES=''
+# MAINTENANCE=''


### PR DESCRIPTION
The max # of Google geocode requests for anonymous apps is [now 5 per second](https://developers.google.com/maps/documentation/geocoding/#Limits). That means we can decrease the min wait time from a second to 200 ms. 

I think we can eliminate the wait entirely. Right now, we're only doing about 500 new geocodes a day, well below Google's 2,500 daily max. It's highly unlikely we'd get >5/second at that rate. 

This PR also adds a tiny readme and a sample env file. 